### PR TITLE
Make a separate blueprint for rpc calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ manager = flask_restless.APIManager(app, flask_sqlalchemy_db=db)
 manager.create_api(Person, methods=['GET'], include_columns=['name'])
 manager.create_api(Computer, methods=['GET'], collection_name='compjutahs', exclude_columns=['name'])
 manager.create_api(data_model, methods=['GET'])
+# In case you want to expose the methods and properties as well
+data_model.register_rpc_blueprint()
 ```
 
 Which will expose an endpoint `http://localhost:5000/flask-restless-datamodel` which in turn will yield a result as followed

--- a/flask_restless_datamodel/__init__.py
+++ b/flask_restless_datamodel/__init__.py
@@ -6,4 +6,4 @@ from . import patches  # noqa
 from .datamodel import DataModel  # noqa
 
 # Check the PBR version module docs for other options than release_string()
-__version__ = "0.2.12"
+__version__ = VersionInfo('flask-restless-datamodel').release_string()

--- a/flask_restless_datamodel/__init__.py
+++ b/flask_restless_datamodel/__init__.py
@@ -6,4 +6,4 @@ from . import patches  # noqa
 from .datamodel import DataModel  # noqa
 
 # Check the PBR version module docs for other options than release_string()
-__version__ = VersionInfo('flask-restless-datamodel').release_string()
+__version__ = "0.2.12"

--- a/flask_restless_datamodel/helpers.py
+++ b/flask_restless_datamodel/helpers.py
@@ -51,6 +51,9 @@ def run_object_method(instid, function_name, model, commit_on_return):
             session.commit()
         except Exception:
             pass
+    else:
+        session = Session.object_session(instance)
+        session.rollback()
 
     return result
 

--- a/flask_restless_datamodel/helpers.py
+++ b/flask_restless_datamodel/helpers.py
@@ -5,7 +5,7 @@ import flask
 from sqlalchemy.orm.session import Session
 
 ModelConfiguration = namedtuple('ModelConfiguration',
-                                'collection_name view blueprint')
+                                'collection_name view blueprint rpc_blueprint')
 
 
 def abort(msg):
@@ -39,9 +39,10 @@ def run_object_method(instid, function_name, model, commit_on_return):
     try:
         result = getattr(instance, function_name)(*params['args'],
                                                   **params['kwargs'])
-        result = json.dumps({'payload': cr().dumps(result)})
+        payload = cr().dumps(result)
+        result = json.dumps({'payload': payload})
     except Exception as e:
-        msg = '{}: {}'.format(e.__class__.__name__, str(e))
+        msg = f'{e.__class__.__name__}: {str(e)}'
         abort(msg)
 
     if commit_on_return:

--- a/flask_restless_datamodel/patches.py
+++ b/flask_restless_datamodel/patches.py
@@ -118,3 +118,6 @@ if sqla_version >= SemanticVersion(1, 3, 0):
     ASSOCIATION_PROXIES_KLASSES = (AssociationProxy,
                                    ObjectAssociationProxyInstance)
     apply_patches()
+
+if sqla_version >= SemanticVersion(2,0,0):
+    flask_restless.helpers.hybrid.HYBRID_PROPERTY = flask_restless.helpers.hybrid.HybridExtensionType.HYBRID_PROPERTY

--- a/flask_restless_datamodel/render.py
+++ b/flask_restless_datamodel/render.py
@@ -208,7 +208,7 @@ class ClassDefinitionRenderer:
     def add_property_endpoint(self, property_name):
         fmt = '/property/{0}/<instid>/{1}'
         endpoint = fmt.format(self.config.collection_name, property_name)
-        self.config.blueprint.add_url_rule(
+        self.config.rpc_blueprint.add_url_rule(
             endpoint,
             methods=['GET', 'POST'],
             defaults={
@@ -274,7 +274,7 @@ class MethodDefinitionRenderer:
         for method in methods.keys():
             fmt = '/method/{0}/<instid>/{1}'
             instance_endpoint = fmt.format(collection_name, method)
-            self.config.blueprint.add_url_rule(
+            self.config.rpc_blueprint.add_url_rule(
                 instance_endpoint,
                 methods=['POST'],
                 defaults={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ def app():
     app.config['DEBUG'] = True
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    return app
+    with app.app_context():
+        yield app
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1,5 +1,4 @@
 from datetime import date
-from unittest.mock import patch
 
 import flask_restless
 import pytest
@@ -239,6 +238,8 @@ def _exposed_method_model_app(app, commit_before_return=False):
         include_model_functions=True,
         commit_on_method_return=commit_before_return)
     manager.create_api(data_model, methods=['GET'])
+    data_model.register_rpc_blueprint()
+
     return app
 
 
@@ -404,7 +405,7 @@ def test_it_can_identify_a_hybrid_property(app, client_maker):
 
         @hybrid_property
         def name(self):
-            return "{} {}".format(self.first_name, self.last_name)
+            return f"{self.first_name} {self.last_name}"
 
     db.create_all()
 


### PR DESCRIPTION
A proposal to make a separate blueprint for RPC calls.
This allows us to not having to call register on the same blueprint multiple times.
I couldn't get the functionality to not auto commit working within the test suite, I suppose there is some changed default behaviour in SQLAlchemy or Flask-SQLAlchemy that is causing this. My knowledge does not run deep enough unfortunately.

I also haven't found a way to automatically register the rpc blueprint after all the models are added. 
There is a possibility to use some sort of context manager, but it will require an adaption of the implementing party anyway. It probably doesn't hurt to be explicit about and give the option to not register the rpc (and just have a CRUD framework)